### PR TITLE
refactor(admin): global feedback providers and UI polish

### DIFF
--- a/apps/frontend/src/app/admin/components/AdminNavBar.tsx
+++ b/apps/frontend/src/app/admin/components/AdminNavBar.tsx
@@ -9,14 +9,7 @@ import {
     Paper,
     Tabs,
     Tab,
-    Typography,
-    Snackbar,
-    Alert,
-    Dialog,
-    DialogTitle,
-    DialogContent,
-    DialogActions,
-    Button
+    Typography
 } from "@mui/material";
 import AccountCircleIcon from "@mui/icons-material/AccountCircle";
 import LanguageIcon from "@mui/icons-material/Language";
@@ -26,6 +19,8 @@ import { useRouter } from "next/navigation";
 import logout from "@/app/actions/auth/logout";
 import LanguageMenu from "@/components/shared/LanguageMenu";
 import UserMenu from "@/components/shared/UserMenu";
+import { useToast } from "@/components/providers/ToastProvider";
+import { useConfirm } from "@/components/providers/ConfirmProvider";
 
 type AdminNavBarProps = {
     activeTab: number;
@@ -35,51 +30,37 @@ type AdminNavBarProps = {
 export const AdminNavBar = ({ activeTab, setActiveTab }: AdminNavBarProps) => {
     const { t, i18n } = useTranslation();
     const router = useRouter();
+    const { showToast } = useToast();
+    const confirm = useConfirm();
 
-    // Menu States
     const [userAnchorEl, setUserAnchorEl] = useState<null | HTMLElement>(null);
     const [langAnchorEl, setLangAnchorEl] = useState<null | HTMLElement>(null);
 
-    // Feedback States
-    const [toast, setToast] = useState<{
-        open: boolean;
-        message: string;
-        severity: "success" | "error";
-    }>({
-        open: false,
-        message: "",
-        severity: "success"
-    });
-    const [logoutDialogOpen, setLogoutDialogOpen] = useState(false);
-
     const handleLogout = async () => {
-        setLogoutDialogOpen(false);
-        const { error } = await logout();
-        if (!error) {
-            router.push("/");
-        } else {
-            setToast({
-                open: true,
-                message: t(
-                    "admin.error.logout_failed",
-                    "Logout failed. Please try again."
-                ),
-                severity: "error"
-            });
+        setUserAnchorEl(null); // Close the menu
+        const ok = await confirm({
+            title: t("admin.menu.logout"),
+            message: t("admin.logout_confirm"),
+            isDanger: true
+        });
+
+        if (ok) {
+            const { error } = await logout();
+            if (!error) {
+                router.push("/");
+            } else {
+                showToast(t("admin.error.logout_failed"), "error");
+            }
         }
     };
 
     const handleSelectLanguage = async (code: string) => {
         await i18n.changeLanguage(code);
         setLangAnchorEl(null);
-        setToast({
-            open: true,
-            message: t(
-                "admin.success.lang_changed",
-                "Language updated successfully"
-            ),
-            severity: "success"
-        });
+        // Use Global Toast here!
+        showToast(
+            t("admin.success.lang_changed", "Language updated successfully")
+        );
     };
 
     const getLanguageLabel = (code: string) =>
@@ -177,72 +158,10 @@ export const AdminNavBar = ({ activeTab, setActiveTab }: AdminNavBarProps) => {
                     <UserMenu
                         anchorEl={userAnchorEl}
                         onClose={() => setUserAnchorEl(null)}
-                        onLogout={() => {
-                            setLogoutDialogOpen(true);
-                        }}
+                        onLogout={handleLogout} // Points directly to the logic now
                     />
                 </Stack>
             </Stack>
-
-            {/* TOAST NOTIFICATION (Snackbar) */}
-            <Snackbar
-                open={toast.open}
-                autoHideDuration={4000}
-                onClose={() => setToast({ ...toast, open: false })}
-                anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
-            >
-                <Alert
-                    onClose={() => setToast({ ...toast, open: false })}
-                    severity={toast.severity}
-                    variant="filled"
-                    sx={{
-                        width: "100%",
-                        borderRadius: "12px",
-                        fontWeight: 600
-                    }}
-                >
-                    {toast.message}
-                </Alert>
-            </Snackbar>
-
-            {/* LOGOUT CONFIRMATION DIALOG */}
-            <Dialog
-                open={logoutDialogOpen}
-                onClose={() => setLogoutDialogOpen(false)}
-                PaperProps={{ sx: { borderRadius: "20px", p: 1 } }}
-            >
-                <DialogTitle sx={{ fontWeight: 800 }}>
-                    {t("admin.menu.logout", "Logout")}?
-                </DialogTitle>
-                <DialogContent>
-                    <Typography sx={{ color: "#6B7280" }}>
-                        {t(
-                            "admin.logout_confirm",
-                            "Are you sure you want to log out of the admin portal?"
-                        )}
-                    </Typography>
-                </DialogContent>
-                <DialogActions sx={{ p: 2, gap: 1 }}>
-                    <Button
-                        onClick={() => setLogoutDialogOpen(false)}
-                        sx={{ color: "#6B7280", fontWeight: 700 }}
-                    >
-                        {t("common.cancel", "Cancel")}
-                    </Button>
-                    <Button
-                        onClick={void handleLogout()}
-                        variant="contained"
-                        sx={{
-                            "bgcolor": "#DC2626",
-                            "&:hover": { bgcolor: "#B91C1C" },
-                            "borderRadius": "10px",
-                            "px": 3
-                        }}
-                    >
-                        {t("admin.menu.logout", "Logout")}
-                    </Button>
-                </DialogActions>
-            </Dialog>
         </Paper>
     );
 };

--- a/apps/frontend/src/app/admin/components/AdminNavBar.tsx
+++ b/apps/frontend/src/app/admin/components/AdminNavBar.tsx
@@ -9,7 +9,14 @@ import {
     Paper,
     Tabs,
     Tab,
-    Typography
+    Typography,
+    Snackbar,
+    Alert,
+    Dialog,
+    DialogTitle,
+    DialogContent,
+    DialogActions,
+    Button
 } from "@mui/material";
 import AccountCircleIcon from "@mui/icons-material/AccountCircle";
 import LanguageIcon from "@mui/icons-material/Language";
@@ -27,25 +34,56 @@ type AdminNavBarProps = {
 
 export const AdminNavBar = ({ activeTab, setActiveTab }: AdminNavBarProps) => {
     const { t, i18n } = useTranslation();
-    const [userAnchorEl, setUserAnchorEl] = useState<null | HTMLElement>(null);
-    const [langAnchorEl, setLangAnchorEl] = useState<null | HTMLElement>(null);
     const router = useRouter();
 
+    // Menu States
+    const [userAnchorEl, setUserAnchorEl] = useState<null | HTMLElement>(null);
+    const [langAnchorEl, setLangAnchorEl] = useState<null | HTMLElement>(null);
+
+    // Feedback States
+    const [toast, setToast] = useState<{
+        open: boolean;
+        message: string;
+        severity: "success" | "error";
+    }>({
+        open: false,
+        message: "",
+        severity: "success"
+    });
+    const [logoutDialogOpen, setLogoutDialogOpen] = useState(false);
+
     const handleLogout = async () => {
+        setLogoutDialogOpen(false);
         const { error } = await logout();
         if (!error) {
             router.push("/");
         } else {
-            alert("Logout failed. Please try again.");
+            setToast({
+                open: true,
+                message: t(
+                    "admin.error.logout_failed",
+                    "Logout failed. Please try again."
+                ),
+                severity: "error"
+            });
         }
     };
-    const getLanguageLabel = (code: string) =>
-        t(`languages.${code}`, code.toUpperCase());
 
     const handleSelectLanguage = async (code: string) => {
         await i18n.changeLanguage(code);
         setLangAnchorEl(null);
+        setToast({
+            open: true,
+            message: t(
+                "admin.success.lang_changed",
+                "Language updated successfully"
+            ),
+            severity: "success"
+        });
     };
+
+    const getLanguageLabel = (code: string) =>
+        t(`languages.${code}`, code.toUpperCase());
 
     return (
         <Paper
@@ -130,7 +168,6 @@ export const AdminNavBar = ({ activeTab, setActiveTab }: AdminNavBarProps) => {
                         }}
                     />
 
-                    {/* PROFILE ICON */}
                     <IconButton
                         onClick={(e) => setUserAnchorEl(e.currentTarget)}
                         sx={{ color: "black", borderRadius: "8px" }}
@@ -141,11 +178,71 @@ export const AdminNavBar = ({ activeTab, setActiveTab }: AdminNavBarProps) => {
                         anchorEl={userAnchorEl}
                         onClose={() => setUserAnchorEl(null)}
                         onLogout={() => {
-                            void handleLogout();
+                            setLogoutDialogOpen(true);
                         }}
                     />
                 </Stack>
             </Stack>
+
+            {/* TOAST NOTIFICATION (Snackbar) */}
+            <Snackbar
+                open={toast.open}
+                autoHideDuration={4000}
+                onClose={() => setToast({ ...toast, open: false })}
+                anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+            >
+                <Alert
+                    onClose={() => setToast({ ...toast, open: false })}
+                    severity={toast.severity}
+                    variant="filled"
+                    sx={{
+                        width: "100%",
+                        borderRadius: "12px",
+                        fontWeight: 600
+                    }}
+                >
+                    {toast.message}
+                </Alert>
+            </Snackbar>
+
+            {/* LOGOUT CONFIRMATION DIALOG */}
+            <Dialog
+                open={logoutDialogOpen}
+                onClose={() => setLogoutDialogOpen(false)}
+                PaperProps={{ sx: { borderRadius: "20px", p: 1 } }}
+            >
+                <DialogTitle sx={{ fontWeight: 800 }}>
+                    {t("admin.menu.logout", "Logout")}?
+                </DialogTitle>
+                <DialogContent>
+                    <Typography sx={{ color: "#6B7280" }}>
+                        {t(
+                            "admin.logout_confirm",
+                            "Are you sure you want to log out of the admin portal?"
+                        )}
+                    </Typography>
+                </DialogContent>
+                <DialogActions sx={{ p: 2, gap: 1 }}>
+                    <Button
+                        onClick={() => setLogoutDialogOpen(false)}
+                        sx={{ color: "#6B7280", fontWeight: 700 }}
+                    >
+                        {t("common.cancel", "Cancel")}
+                    </Button>
+                    <Button
+                        onClick={void handleLogout()}
+                        variant="contained"
+                        sx={{
+                            "bgcolor": "#DC2626",
+                            "&:hover": { bgcolor: "#B91C1C" },
+                            "borderRadius": "10px",
+                            "px": 3
+                        }}
+                    >
+                        {t("admin.menu.logout", "Logout")}
+                    </Button>
+                </DialogActions>
+            </Dialog>
         </Paper>
     );
 };

--- a/apps/frontend/src/app/admin/components/AdminNavBar.tsx
+++ b/apps/frontend/src/app/admin/components/AdminNavBar.tsx
@@ -37,7 +37,7 @@ export const AdminNavBar = ({ activeTab, setActiveTab }: AdminNavBarProps) => {
     const [langAnchorEl, setLangAnchorEl] = useState<null | HTMLElement>(null);
 
     const handleLogout = async () => {
-        setUserAnchorEl(null); // Close the menu
+        setUserAnchorEl(null);
         const ok = await confirm({
             title: t("admin.menu.logout"),
             message: t("admin.logout_confirm"),
@@ -57,7 +57,6 @@ export const AdminNavBar = ({ activeTab, setActiveTab }: AdminNavBarProps) => {
     const handleSelectLanguage = async (code: string) => {
         await i18n.changeLanguage(code);
         setLangAnchorEl(null);
-        // Use Global Toast here!
         showToast(
             t("admin.success.lang_changed", "Language updated successfully")
         );
@@ -158,7 +157,7 @@ export const AdminNavBar = ({ activeTab, setActiveTab }: AdminNavBarProps) => {
                     <UserMenu
                         anchorEl={userAnchorEl}
                         onClose={() => setUserAnchorEl(null)}
-                        onLogout={handleLogout} // Points directly to the logic now
+                        onLogout={() => { void handleLogout(); }}
                     />
                 </Stack>
             </Stack>

--- a/apps/frontend/src/app/admin/components/AdminNavBar.tsx
+++ b/apps/frontend/src/app/admin/components/AdminNavBar.tsx
@@ -39,8 +39,11 @@ export const AdminNavBar = ({ activeTab, setActiveTab }: AdminNavBarProps) => {
     const handleLogout = async () => {
         setUserAnchorEl(null);
         const ok = await confirm({
-            title: t("admin.menu.logout"),
-            message: t("admin.logout_confirm"),
+            title: t("admin.menu.logout", "Logout"),
+            message: t(
+                "admin.logout_confirm",
+                "Are you sure you want to log out of the admin portal?"
+            ),
             isDanger: true
         });
 
@@ -49,7 +52,13 @@ export const AdminNavBar = ({ activeTab, setActiveTab }: AdminNavBarProps) => {
             if (!error) {
                 router.push("/");
             } else {
-                showToast(t("admin.error.logout_failed"), "error");
+                showToast(
+                    t(
+                        "admin.error.logout_failed",
+                        "Logout failed. Please try again."
+                    ),
+                    "error"
+                );
             }
         }
     };
@@ -157,7 +166,9 @@ export const AdminNavBar = ({ activeTab, setActiveTab }: AdminNavBarProps) => {
                     <UserMenu
                         anchorEl={userAnchorEl}
                         onClose={() => setUserAnchorEl(null)}
-                        onLogout={() => { void handleLogout(); }}
+                        onLogout={() => {
+                            void handleLogout();
+                        }}
                     />
                 </Stack>
             </Stack>

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -4,6 +4,8 @@ import I18nInit from "@/components/I18nInit";
 import { NavBar } from "@/components/NavBar";
 import "./globals.css";
 import Footer from "@/components/Footer";
+import { ToastProvider } from "@/components/providers/ToastProvider";
+import { ConfirmProvider } from "@/components/providers/ConfirmProvider";
 
 export const metadata: Metadata = {
     title: "Poblaria",
@@ -15,9 +17,13 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <html lang="en">
             <body style={{ margin: 0 }}>
                 <I18nInit />
-                <NavBar />
-                {children}
-                <Footer />
+                <ConfirmProvider>
+                    <ToastProvider>
+                        <NavBar />
+                        {children}
+                        <Footer />
+                    </ToastProvider>
+                </ConfirmProvider>
             </body>
         </html>
     );

--- a/apps/frontend/src/components/providers/ConfirmProvider.tsx
+++ b/apps/frontend/src/components/providers/ConfirmProvider.tsx
@@ -41,7 +41,7 @@ export const ConfirmProvider = ({ children }: { children: ReactNode }) => {
                     PaperProps={{ sx: { borderRadius: "20px", p: 1 } }}
                 >
                     <DialogTitle sx={{ fontWeight: 800 }}>
-                        {state.options.title}?
+                        {state.options.title}
                     </DialogTitle>
                     <DialogContent>
                         <Typography sx={{ color: "#6B7280" }}>

--- a/apps/frontend/src/components/providers/ConfirmProvider.tsx
+++ b/apps/frontend/src/components/providers/ConfirmProvider.tsx
@@ -23,8 +23,15 @@ export const ConfirmProvider = ({ children }: { children: ReactNode }) => {
         options: ConfirmOptions;
     } | null>(null);
 
-    const confirm = (options: ConfirmOptions) =>
-        new Promise<boolean>((resolve) => setState({ resolve, options }));
+    // Refuse new confirms if one is pending to prevent Promise loss
+    const confirm = (options: ConfirmOptions) => {
+        if (state !== null) {
+            return Promise.resolve(false);
+        }
+        return new Promise<boolean>((resolve) =>
+            setState({ resolve, options })
+        );
+    };
 
     const handleClose = (value: boolean) => {
         state?.resolve(value);

--- a/apps/frontend/src/components/providers/ConfirmProvider.tsx
+++ b/apps/frontend/src/components/providers/ConfirmProvider.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import React, { createContext, useContext, useState, ReactNode } from "react";
+import {
+    Dialog,
+    DialogTitle,
+    DialogContent,
+    DialogActions,
+    Button,
+    Typography
+} from "@mui/material";
+import { useTranslation } from "react-i18next";
+
+type ConfirmOptions = { title: string; message: string; isDanger?: boolean };
+type ConfirmContextType = (options: ConfirmOptions) => Promise<boolean>;
+
+const ConfirmContext = createContext<ConfirmContextType | undefined>(undefined);
+
+export const ConfirmProvider = ({ children }: { children: ReactNode }) => {
+    const { t } = useTranslation();
+    const [state, setState] = useState<{
+        resolve: (v: boolean) => void;
+        options: ConfirmOptions;
+    } | null>(null);
+
+    const confirm = (options: ConfirmOptions) =>
+        new Promise<boolean>((resolve) => setState({ resolve, options }));
+
+    const handleClose = (value: boolean) => {
+        state?.resolve(value);
+        setState(null);
+    };
+
+    return (
+        <ConfirmContext.Provider value={confirm}>
+            {children}
+            {state && (
+                <Dialog
+                    open={!!state}
+                    onClose={() => handleClose(false)}
+                    PaperProps={{ sx: { borderRadius: "20px", p: 1 } }}
+                >
+                    <DialogTitle sx={{ fontWeight: 800 }}>
+                        {state.options.title}?
+                    </DialogTitle>
+                    <DialogContent>
+                        <Typography sx={{ color: "#6B7280" }}>
+                            {state.options.message}
+                        </Typography>
+                    </DialogContent>
+                    <DialogActions sx={{ p: 2, gap: 1 }}>
+                        <Button
+                            onClick={() => handleClose(false)}
+                            sx={{ color: "#6B7280", fontWeight: 700 }}
+                        >
+                            {t("common.cancel", "Cancel")}
+                        </Button>
+                        <Button
+                            variant="contained"
+                            onClick={() => handleClose(true)}
+                            sx={{
+                                bgcolor: state.options.isDanger
+                                    ? "#DC2626"
+                                    : "#5E7749",
+                                borderRadius: "10px",
+                                px: 3
+                            }}
+                        >
+                            {t("common.confirm", "Confirm")}
+                        </Button>
+                    </DialogActions>
+                </Dialog>
+            )}
+        </ConfirmContext.Provider>
+    );
+};
+
+export const useConfirm = () => {
+    const context = useContext(ConfirmContext);
+    if (!context)
+        throw new Error("useConfirm must be used within ConfirmProvider");
+    return context;
+};

--- a/apps/frontend/src/components/providers/ToastProvider.tsx
+++ b/apps/frontend/src/components/providers/ToastProvider.tsx
@@ -13,17 +13,21 @@ export const ToastProvider = ({ children }: { children: ReactNode }) => {
     const [open, setOpen] = useState(false);
     const [message, setMessage] = useState("");
     const [severity, setSeverity] = useState<AlertColor>("success");
+    // Use a key to force Snackbar to restart the timer on new messages
+    const [toastKey, setToastKey] = useState(0);
 
     const showToast = (msg: string, sev: AlertColor = "success") => {
         setMessage(msg);
         setSeverity(sev);
         setOpen(true);
+        setToastKey((prev) => prev + 1);
     };
 
     return (
         <ToastContext.Provider value={{ showToast }}>
             {children}
             <Snackbar
+                key={toastKey}
                 open={open}
                 autoHideDuration={4000}
                 onClose={() => setOpen(false)}

--- a/apps/frontend/src/components/providers/ToastProvider.tsx
+++ b/apps/frontend/src/components/providers/ToastProvider.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import React, { createContext, useContext, useState, ReactNode } from "react";
+import { Snackbar, Alert, AlertColor } from "@mui/material";
+
+type ToastContextType = {
+    showToast: (message: string, severity?: AlertColor) => void;
+};
+
+const ToastContext = createContext<ToastContextType | undefined>(undefined);
+
+export const ToastProvider = ({ children }: { children: ReactNode }) => {
+    const [open, setOpen] = useState(false);
+    const [message, setMessage] = useState("");
+    const [severity, setSeverity] = useState<AlertColor>("success");
+
+    const showToast = (msg: string, sev: AlertColor = "success") => {
+        setMessage(msg);
+        setSeverity(sev);
+        setOpen(true);
+    };
+
+    return (
+        <ToastContext.Provider value={{ showToast }}>
+            {children}
+            <Snackbar
+                open={open}
+                autoHideDuration={4000}
+                onClose={() => setOpen(false)}
+                anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+            >
+                <Alert
+                    onClose={() => setOpen(false)}
+                    severity={severity}
+                    variant="filled"
+                    sx={{
+                        width: "100%",
+                        borderRadius: "12px",
+                        fontWeight: 600
+                    }}
+                >
+                    {message}
+                </Alert>
+            </Snackbar>
+        </ToastContext.Provider>
+    );
+};
+
+export const useToast = () => {
+    const context = useContext(ToastContext);
+    if (!context)
+        throw new Error("useToast must be used within a ToastProvider");
+    return context;
+};

--- a/apps/frontend/src/locales/en.json
+++ b/apps/frontend/src/locales/en.json
@@ -92,10 +92,14 @@
         },
         "menu": { "client_view": "Switch to Client View", "logout": "Logout" },
         "loading": "Verifying credentials...",
-        "statistics": {
-            "total": "Total",
-            "new": "New"
+        "success": {
+            "lang_changed": "Language updated successfully"
         },
+        "error": {
+            "logout_failed": "Logout failed. Please try again."
+        },
+        "logout_confirm": "Are you sure you want to log out of the admin portal?",
+        "statistics": { "total": "Total", "new": "New" },
         "growth_label": "GROWTH STATUS",
         "growth_positive": "Expanded by",
         "growth_units": "units",

--- a/apps/frontend/src/locales/es.json
+++ b/apps/frontend/src/locales/es.json
@@ -94,12 +94,13 @@
             "logout": "Cerrar sesión"
         },
         "loading": "Verificando credenciales...",
-        "error": {
-            "denied_title": "Acceso Denegado",
-            "denied_desc": "No tienes permiso para ver el Portal de Administración.",
-            "redirect_msg": "Redirigiendo en",
-            "seconds": "segundos"
+        "success": {
+            "lang_changed": "Idioma actualizado correctamente"
         },
+        "error": {
+            "logout_failed": "Error al cerrar sesión. Inténtalo de nuevo."
+        },
+        "logout_confirm": "¿Estás seguro de que quieres cerrar la sesión del portal de administración?",
         "newsletter": {
             "load_btn": "Cargar Suscriptores",
             "found": "Suscriptores Encontrados",

--- a/apps/frontend/src/locales/fr.json
+++ b/apps/frontend/src/locales/fr.json
@@ -93,12 +93,13 @@
         },
         "menu": { "client_view": "Vue Client", "logout": "Déconnexion" },
         "loading": "Vérification des identifiants...",
-        "error": {
-            "denied_title": "Accès Refusé",
-            "denied_desc": "Vous n'avez pas l'autorisation d'accéder au portail administrateur.",
-            "redirect_msg": "Redirection vers l'accueil dans",
-            "seconds": "secondes"
+        "success": {
+            "lang_changed": "Langue mise à jour avec succès"
         },
+        "error": {
+            "logout_failed": "Échec de la déconnexion. Veuillez réessayer."
+        },
+        "logout_confirm": "Êtes-vous sûr de vouloir vous déconnecter du portail administrateur ?",
         "newsletter": {
             "load_btn": "Charger les Abonnés",
             "found": "Abonnés Trouvés",


### PR DESCRIPTION
As requested, I've moved the Toast and Confirmation Dialog logic into global providers in the root layout. This makes them usable across the entire app. I also resolved the build errors related to MUI Charts and TypeScript promises.