### PR TITLE
feat(profile): connect change password & delete account with backend

### DIFF
--- a/apps/frontend/src/app/profile/components/AccountSecurity.tsx
+++ b/apps/frontend/src/app/profile/components/AccountSecurity.tsx
@@ -138,7 +138,7 @@ export default function AccountSecurity() {
                     )}
                     <Button
                         variant="contained"
-                        onClick={handleChangePassword}
+                        onClick={() => handleChangePassword()}
                         sx={{
                             bgcolor: "#111827",
                             textTransform: "none",
@@ -164,7 +164,7 @@ export default function AccountSecurity() {
                     variant="outlined"
                     color="error"
                     sx={{ textTransform: "none" }}
-                    onClick={handleDeleteUser}
+                    onClick={() => handleDeleteUser()}
                 >
                     {t("profile.permanentlyDelete")}
                 </Button>

--- a/apps/frontend/src/app/profile/components/AccountSecurity.tsx
+++ b/apps/frontend/src/app/profile/components/AccountSecurity.tsx
@@ -43,9 +43,8 @@ export default function AccountSecurity() {
             newPassword
         });
         if (error) {
-            const err = error as { errors?: { message: string }[] };
             showToast(
-                err.errors?.[0]?.message ?? t("auth.login.errors.generic"),
+                error.errors?.[0]?.message ?? t("auth.login.errors.generic"),
                 "error"
             );
         } else {
@@ -63,13 +62,9 @@ export default function AccountSecurity() {
             isDanger: true
         });
         if (!confirmed || !user?.id) return;
-        const { error } = await deleteUser(String(user.id));
-        if (error) {
-            const err = error as { errors?: { message: string }[] };
-            showToast(
-                err.errors?.[0]?.message ?? t("auth.login.errors.generic"),
-                "error"
-            );
+        const ok = await deleteUser(String(user.id));
+        if (!ok) {
+            showToast(t("auth.login.errors.generic"), "error");
         } else {
             await refreshUser();
             router.push("/");

--- a/apps/frontend/src/app/profile/components/AccountSecurity.tsx
+++ b/apps/frontend/src/app/profile/components/AccountSecurity.tsx
@@ -6,7 +6,12 @@ import {
     Button,
     Tooltip,
     IconButton,
-    Alert
+    Alert,
+    Dialog,
+    DialogTitle,
+    DialogContent,
+    DialogContentText,
+    DialogActions
 } from "@mui/material";
 import InfoIcon from "@mui/icons-material/Info";
 import { useTranslation } from "react-i18next";
@@ -25,16 +30,14 @@ export default function AccountSecurity() {
         type: "success" | "error";
         text: string;
     } | null>(null);
+    const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
     const isWeakPassword = (pwd: string) => pwd.length < 8;
 
     const handleChangePassword = async () => {
         setPasswordMsg(null);
         if (isWeakPassword(newPassword)) {
-            setPasswordMsg({
-                type: "error",
-                text: t("profile.passwordRules")
-            });
+            setPasswordMsg({ type: "error", text: t("profile.passwordRules") });
             return;
         }
         if (newPassword !== confirmPassword) {
@@ -66,7 +69,7 @@ export default function AccountSecurity() {
     };
 
     const handleDeleteUser = async () => {
-        if (!user?.id || !confirm(t("profile.deleteAccountConfirm"))) return;
+        if (!user?.id) return;
         const { error } = await deleteUser(String(user.id));
         if (error) {
             const err = error as { errors?: { message: string }[] };
@@ -74,6 +77,7 @@ export default function AccountSecurity() {
         } else {
             window.location.href = "/";
         }
+        setDeleteDialogOpen(false);
     };
 
     return (
@@ -138,7 +142,7 @@ export default function AccountSecurity() {
                     )}
                     <Button
                         variant="contained"
-                        onClick={() => handleChangePassword()}
+                        onClick={() => void handleChangePassword()}
                         sx={{
                             bgcolor: "#111827",
                             textTransform: "none",
@@ -150,6 +154,7 @@ export default function AccountSecurity() {
                     </Button>
                 </Box>
             </Box>
+
             <Box sx={{ mt: 2, pt: 4, borderTop: "1px solid #E5E7EB" }}>
                 <Typography
                     variant="h6"
@@ -164,11 +169,41 @@ export default function AccountSecurity() {
                     variant="outlined"
                     color="error"
                     sx={{ textTransform: "none" }}
-                    onClick={() => handleDeleteUser()}
+                    onClick={() => setDeleteDialogOpen(true)}
                 >
                     {t("profile.permanentlyDelete")}
                 </Button>
             </Box>
+
+            <Dialog
+                open={deleteDialogOpen}
+                onClose={() => setDeleteDialogOpen(false)}
+            >
+                <DialogTitle sx={{ fontWeight: 700 }}>
+                    {t("profile.deleteAccount")}
+                </DialogTitle>
+                <DialogContent>
+                    <DialogContentText>
+                        {t("profile.deleteAccountConfirm")}
+                    </DialogContentText>
+                </DialogContent>
+                <DialogActions>
+                    <Button
+                        onClick={() => setDeleteDialogOpen(false)}
+                        sx={{ textTransform: "none" }}
+                    >
+                        {t("common.cancel")}
+                    </Button>
+                    <Button
+                        onClick={() => void handleDeleteUser()}
+                        color="error"
+                        variant="contained"
+                        sx={{ textTransform: "none" }}
+                    >
+                        {t("profile.permanentlyDelete")}
+                    </Button>
+                </DialogActions>
+            </Dialog>
         </Box>
     );
 }

--- a/apps/frontend/src/app/profile/components/AccountSecurity.tsx
+++ b/apps/frontend/src/app/profile/components/AccountSecurity.tsx
@@ -1,16 +1,81 @@
+"use client";
 import {
     Box,
     Typography,
     TextField,
     Button,
     Tooltip,
-    IconButton
+    IconButton,
+    Alert
 } from "@mui/material";
 import InfoIcon from "@mui/icons-material/Info";
 import { useTranslation } from "react-i18next";
+import { useState } from "react";
+import changePassword from "@/app/actions/auth/changePassword";
+import deleteUser from "@/app/actions/users/deleteUser";
+import { useAuth } from "@/components/providers/AuthProvider";
 
 export default function AccountSecurity() {
     const { t } = useTranslation();
+    const { user } = useAuth();
+    const [currentPassword, setCurrentPassword] = useState("");
+    const [newPassword, setNewPassword] = useState("");
+    const [confirmPassword, setConfirmPassword] = useState("");
+    const [passwordMsg, setPasswordMsg] = useState<{
+        type: "success" | "error";
+        text: string;
+    } | null>(null);
+
+    const isWeakPassword = (pwd: string) => pwd.length < 8;
+
+    const handleChangePassword = async () => {
+        setPasswordMsg(null);
+        if (isWeakPassword(newPassword)) {
+            setPasswordMsg({
+                type: "error",
+                text: t("profile.passwordRules")
+            });
+            return;
+        }
+        if (newPassword !== confirmPassword) {
+            setPasswordMsg({
+                type: "error",
+                text: t("profile.passwordMismatch")
+            });
+            return;
+        }
+        const { error } = await changePassword({
+            currentPassword,
+            newPassword
+        });
+        if (error) {
+            const err = error as { errors?: { message: string }[] };
+            setPasswordMsg({
+                type: "error",
+                text: err.errors?.[0]?.message ?? t("auth.login.errors.generic")
+            });
+        } else {
+            setPasswordMsg({
+                type: "success",
+                text: t("profile.passwordChanged")
+            });
+            setCurrentPassword("");
+            setNewPassword("");
+            setConfirmPassword("");
+        }
+    };
+
+    const handleDeleteUser = async () => {
+        if (!user?.id || !confirm(t("profile.deleteAccountConfirm"))) return;
+        const { error } = await deleteUser(String(user.id));
+        if (error) {
+            const err = error as { errors?: { message: string }[] };
+            alert(err.errors?.[0]?.message ?? t("auth.login.errors.generic"));
+        } else {
+            window.location.href = "/";
+        }
+    };
+
     return (
         <Box
             sx={{
@@ -38,42 +103,42 @@ export default function AccountSecurity() {
                         </IconButton>
                     </Tooltip>
                 </Box>
-                <Typography
-                    sx={{
-                        color: "#6B7280",
-                        mb: 3,
-                        fontSize: 14
-                    }}
-                >
-                    {t(
-                        "profile.passwordDescription",
-                        "Ensure your account is using a long, random password to stay secure."
-                    )}
+                <Typography sx={{ color: "#6B7280", mb: 3, fontSize: 14 }}>
+                    {t("profile.passwordDescription")}
                 </Typography>
-                <Box
-                    sx={{
-                        display: "flex",
-                        flexDirection: "column",
-                        gap: 2
-                    }}
-                >
+                <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
                     <TextField
                         fullWidth
                         type="password"
-                        label={t("profile.newPassword", "New Password")}
                         size="small"
+                        label={t("profile.currentPassword", "Current Password")}
+                        value={currentPassword}
+                        onChange={(e) => setCurrentPassword(e.target.value)}
                     />
                     <TextField
                         fullWidth
                         type="password"
-                        label={t(
-                            "profile.confirmPassword",
-                            "Confirm New Password"
-                        )}
                         size="small"
+                        label={t("profile.newPassword")}
+                        value={newPassword}
+                        onChange={(e) => setNewPassword(e.target.value)}
                     />
+                    <TextField
+                        fullWidth
+                        type="password"
+                        size="small"
+                        label={t("profile.confirmPassword")}
+                        value={confirmPassword}
+                        onChange={(e) => setConfirmPassword(e.target.value)}
+                    />
+                    {passwordMsg && (
+                        <Alert severity={passwordMsg.type}>
+                            {passwordMsg.text}
+                        </Alert>
+                    )}
                     <Button
                         variant="contained"
+                        onClick={handleChangePassword}
                         sx={{
                             bgcolor: "#111827",
                             textTransform: "none",
@@ -81,48 +146,27 @@ export default function AccountSecurity() {
                             px: 4
                         }}
                     >
-                        {t("profile.savePassword", "Save Password")}
+                        {t("profile.savePassword")}
                     </Button>
                 </Box>
             </Box>
-            <Box
-                sx={{
-                    mt: 2,
-                    pt: 4,
-                    borderTop: "1px solid #E5E7EB"
-                }}
-            >
+            <Box sx={{ mt: 2, pt: 4, borderTop: "1px solid #E5E7EB" }}>
                 <Typography
                     variant="h6"
-                    sx={{
-                        fontWeight: 700,
-                        color: "#991B1B",
-                        mb: 1
-                    }}
+                    sx={{ fontWeight: 700, color: "#991B1B", mb: 1 }}
                 >
-                    {t("profile.deleteAccount", "Delete Account")}
+                    {t("profile.deleteAccount")}
                 </Typography>
-                <Typography
-                    sx={{
-                        color: "#6B7280",
-                        mb: 3,
-                        fontSize: 14
-                    }}
-                >
-                    {t(
-                        "profile.deleteAccountDescription",
-                        "Once your account is deleted, all of its resources and data will be permanently deleted."
-                    )}
+                <Typography sx={{ color: "#6B7280", mb: 3, fontSize: 14 }}>
+                    {t("profile.deleteAccountDescription")}
                 </Typography>
                 <Button
                     variant="outlined"
                     color="error"
                     sx={{ textTransform: "none" }}
+                    onClick={handleDeleteUser}
                 >
-                    {t(
-                        "profile.permanentlyDelete",
-                        "Permanently Delete Account"
-                    )}
+                    {t("profile.permanentlyDelete")}
                 </Button>
             </Box>
         </Box>

--- a/apps/frontend/src/app/profile/components/AccountSecurity.tsx
+++ b/apps/frontend/src/app/profile/components/AccountSecurity.tsx
@@ -5,46 +5,37 @@ import {
     TextField,
     Button,
     Tooltip,
-    IconButton,
-    Alert,
-    Dialog,
-    DialogTitle,
-    DialogContent,
-    DialogContentText,
-    DialogActions
+    IconButton
 } from "@mui/material";
 import InfoIcon from "@mui/icons-material/Info";
 import { useTranslation } from "react-i18next";
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 import changePassword from "@/app/actions/auth/changePassword";
 import deleteUser from "@/app/actions/users/deleteUser";
 import { useAuth } from "@/components/providers/AuthProvider";
+import { useConfirm } from "@/components/providers/ConfirmProvider";
+import { useToast } from "@/components/providers/ToastProvider";
 
 export default function AccountSecurity() {
     const { t } = useTranslation();
     const { user } = useAuth();
+    const confirm = useConfirm();
+    const { showToast } = useToast();
+    const router = useRouter();
     const [currentPassword, setCurrentPassword] = useState("");
     const [newPassword, setNewPassword] = useState("");
     const [confirmPassword, setConfirmPassword] = useState("");
-    const [passwordMsg, setPasswordMsg] = useState<{
-        type: "success" | "error";
-        text: string;
-    } | null>(null);
-    const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
     const isWeakPassword = (pwd: string) => pwd.length < 8;
 
     const handleChangePassword = async () => {
-        setPasswordMsg(null);
         if (isWeakPassword(newPassword)) {
-            setPasswordMsg({ type: "error", text: t("profile.passwordRules") });
+            showToast(t("profile.passwordRules"), "error");
             return;
         }
         if (newPassword !== confirmPassword) {
-            setPasswordMsg({
-                type: "error",
-                text: t("profile.passwordMismatch")
-            });
+            showToast(t("profile.passwordMismatch"), "error");
             return;
         }
         const { error } = await changePassword({
@@ -53,15 +44,12 @@ export default function AccountSecurity() {
         });
         if (error) {
             const err = error as { errors?: { message: string }[] };
-            setPasswordMsg({
-                type: "error",
-                text: err.errors?.[0]?.message ?? t("auth.login.errors.generic")
-            });
+            showToast(
+                err.errors?.[0]?.message ?? t("auth.login.errors.generic"),
+                "error"
+            );
         } else {
-            setPasswordMsg({
-                type: "success",
-                text: t("profile.passwordChanged")
-            });
+            showToast(t("profile.passwordChanged"), "success");
             setCurrentPassword("");
             setNewPassword("");
             setConfirmPassword("");
@@ -69,15 +57,22 @@ export default function AccountSecurity() {
     };
 
     const handleDeleteUser = async () => {
-        if (!user?.id) return;
+        const confirmed = await confirm({
+            title: t("profile.deleteAccount"),
+            message: t("profile.deleteAccountConfirm"),
+            isDanger: true
+        });
+        if (!confirmed || !user?.id) return;
         const { error } = await deleteUser(String(user.id));
         if (error) {
             const err = error as { errors?: { message: string }[] };
-            alert(err.errors?.[0]?.message ?? t("auth.login.errors.generic"));
+            showToast(
+                err.errors?.[0]?.message ?? t("auth.login.errors.generic"),
+                "error"
+            );
         } else {
-            window.location.href = "/";
+            router.push("/");
         }
-        setDeleteDialogOpen(false);
     };
 
     return (
@@ -99,7 +94,7 @@ export default function AccountSecurity() {
                     }}
                 >
                     <Typography variant="h6" sx={{ fontWeight: 700 }}>
-                        {t("profile.changePassword", "Change Password")}
+                        {t("profile.changePassword")}
                     </Typography>
                     <Tooltip title={t("profile.passwordRules")}>
                         <IconButton>
@@ -115,7 +110,7 @@ export default function AccountSecurity() {
                         fullWidth
                         type="password"
                         size="small"
-                        label={t("profile.currentPassword", "Current Password")}
+                        label={t("profile.currentPassword")}
                         value={currentPassword}
                         onChange={(e) => setCurrentPassword(e.target.value)}
                     />
@@ -135,11 +130,6 @@ export default function AccountSecurity() {
                         value={confirmPassword}
                         onChange={(e) => setConfirmPassword(e.target.value)}
                     />
-                    {passwordMsg && (
-                        <Alert severity={passwordMsg.type}>
-                            {passwordMsg.text}
-                        </Alert>
-                    )}
                     <Button
                         variant="contained"
                         onClick={() => void handleChangePassword()}
@@ -169,41 +159,11 @@ export default function AccountSecurity() {
                     variant="outlined"
                     color="error"
                     sx={{ textTransform: "none" }}
-                    onClick={() => setDeleteDialogOpen(true)}
+                    onClick={() => void handleDeleteUser()}
                 >
                     {t("profile.permanentlyDelete")}
                 </Button>
             </Box>
-
-            <Dialog
-                open={deleteDialogOpen}
-                onClose={() => setDeleteDialogOpen(false)}
-            >
-                <DialogTitle sx={{ fontWeight: 700 }}>
-                    {t("profile.deleteAccount")}
-                </DialogTitle>
-                <DialogContent>
-                    <DialogContentText>
-                        {t("profile.deleteAccountConfirm")}
-                    </DialogContentText>
-                </DialogContent>
-                <DialogActions>
-                    <Button
-                        onClick={() => setDeleteDialogOpen(false)}
-                        sx={{ textTransform: "none" }}
-                    >
-                        {t("common.cancel")}
-                    </Button>
-                    <Button
-                        onClick={() => void handleDeleteUser()}
-                        color="error"
-                        variant="contained"
-                        sx={{ textTransform: "none" }}
-                    >
-                        {t("profile.permanentlyDelete")}
-                    </Button>
-                </DialogActions>
-            </Dialog>
         </Box>
     );
 }

--- a/apps/frontend/src/app/profile/components/AccountSecurity.tsx
+++ b/apps/frontend/src/app/profile/components/AccountSecurity.tsx
@@ -19,7 +19,7 @@ import { useToast } from "@/components/providers/ToastProvider";
 
 export default function AccountSecurity() {
     const { t } = useTranslation();
-    const { user } = useAuth();
+    const { user, refreshUser } = useAuth();
     const confirm = useConfirm();
     const { showToast } = useToast();
     const router = useRouter();
@@ -71,6 +71,7 @@ export default function AccountSecurity() {
                 "error"
             );
         } else {
+            await refreshUser();
             router.push("/");
         }
     };

--- a/apps/frontend/src/app/profile/components/ProfileHeader.tsx
+++ b/apps/frontend/src/app/profile/components/ProfileHeader.tsx
@@ -22,8 +22,10 @@ export default function ProfileHeader({ userName }: Props) {
             <Box
                 sx={{
                     display: "flex",
+                    flexDirection: { xs: "column", sm: "row" },
                     justifyContent: "space-between",
-                    alignItems: "baseline",
+                    alignItems: { xs: "flex-start", sm: "baseline" },
+                    gap: { xs: 1, sm: 0 },
                     mb: 4
                 }}
             >

--- a/apps/frontend/src/locales/en.json
+++ b/apps/frontend/src/locales/en.json
@@ -128,14 +128,19 @@
         "supportPlaceholder": "Add support content here.",
         "resource": "Resource",
         "resourcePlaceholder": "Add resource links here.",
-        "passwordRules": "The password must be at least 8 characters long, including an uppercase letter, a lowercase letter, a number, and a special character.",
+        "passwordRules": "The password must be at least 8 characters long.",
         "passwordDescription": "Ensure your account is using a long, random password to stay secure.",
         "newPassword": "New Password",
         "savePassword": "Save Password",
         "deleteAccount": "Delete Account",
         "deleteAccountDescription": "Once your account is deleted, all of its resources and data will be permanently deleted.",
         "permanentlyDelete": "Permanently Delete Account",
-        "confirmPassword": "Confirm Password"
+        "confirmPassword": "Confirm Password",
+        "currentPassword": "Current Password",
+        "changePassword": "Change Password",
+        "passwordMismatch": "Passwords do not match.",
+        "passwordChanged": "Password updated successfully.",
+        "deleteAccountConfirm": "Are you sure? This action is irreversible."
     },
     "auth": {
         "signup": {

--- a/apps/frontend/src/locales/es.json
+++ b/apps/frontend/src/locales/es.json
@@ -130,14 +130,19 @@
         "supportPlaceholder": "Añade contenido de soporte aquí.",
         "resource": "Recurso",
         "resourcePlaceholder": "Añade enlaces de recursos aquí.",
-        "passwordRules": "La contraseña debe tener al menos 8 caracteres, incluyendo una mayúscula, una minúscula, un número y un carácter especial.",
+        "passwordRules": "La contraseña debe tener al menos 8 caracteres.",
         "passwordDescription": "Asegúrate de que tu cuenta utilice una contraseña larga y aleatoria para mantenerla segura.",
         "newPassword": "Nueva contraseña",
         "savePassword": "Guardar contraseña",
         "deleteAccount": "Eliminar cuenta",
         "deleteAccountDescription": "Una vez que tu cuenta sea eliminada, todos sus recursos y datos serán eliminados permanentemente.",
         "permanentlyDelete": "Eliminar cuenta permanentemente",
-        "confirmPassword": "Confirmar contraseña"
+        "confirmPassword": "Confirmar contraseña",
+        "currentPassword": "Contraseña actual",
+        "changePassword": "Cambiar contraseña",
+        "passwordMismatch": "Las contraseñas no coinciden.",
+        "passwordChanged": "Contraseña actualizada correctamente.",
+        "deleteAccountConfirm": "¿Estás seguro? Esta acción es irreversible."
     },
     "auth": {
         "signup": {

--- a/apps/frontend/src/locales/fr.json
+++ b/apps/frontend/src/locales/fr.json
@@ -129,14 +129,19 @@
         "supportPlaceholder": "Ajoutez du contenu de support ici.",
         "resource": "Ressource",
         "resourcePlaceholder": "Ajoutez des liens de ressources ici.",
-        "passwordRules": "Le mot de passe doit contenir au moins 8 caractères, y compris une majuscule, une minuscule, un chiffre et un caractère spécial.",
+        "passwordRules": "Le mot de passe doit contenir au moins 8 caractères.",
         "passwordDescription": "Assurez-vous que votre compte utilise un mot de passe long et aléatoire pour rester sécurisé.",
         "newPassword": "Nouveau mot de passe",
         "savePassword": "Enregistrer le mot de passe",
         "deleteAccount": "Supprimer le compte",
         "deleteAccountDescription": "Une fois votre compte supprimé, toutes ses ressources et données seront définitivement supprimées.",
         "permanentlyDelete": "Supprimer définitivement le compte",
-        "confirmPassword": "Confirmer le mot de passe"
+        "confirmPassword": "Confirmer le mot de passe",
+        "currentPassword": "Mot de passe actuel",
+        "changePassword": "Changer le mot de passe",
+        "passwordMismatch": "Les mots de passe ne correspondent pas.",
+        "passwordChanged": "Mot de passe mis à jour avec succès.",
+        "deleteAccountConfirm": "Êtes-vous sûr ? Cette action est irréversible."
     },
     "auth": {
         "signup": {


### PR DESCRIPTION
## Summary
Connects the Account Security profile page to the backend for password  change and account deletion flows.

## Changes
- Wire up `changePassword` action with current/new/confirm password fields
- Add client-side weak password validation (min. 8 characters)
- Add MUI Dialog for account deletion confirmation replacing native `confirm()`
- Wire up `deleteUser` action and redirect to `/` on success
- Fix error handling by casting Tuyau's `never` error type to AdonisJS error shape
- Fix `ProfileHeader` layout to stack on mobile (welcome + become a host row)
- Update `profile.passwordRules` translation in `en.json`, `es.json`, `fr.json` 
  to match backend validation (min. 8 characters only)